### PR TITLE
Queue: Add drain() method that consumes all pending items and immedia…

### DIFF
--- a/src/QueueInterface.php
+++ b/src/QueueInterface.php
@@ -16,6 +16,10 @@ interface QueueInterface
      */
     public function consume(callable $callback, float $timeoutSecs, ?float $pollIntervalSecs): void;
 
+    /**
+     * @param callable $callback Callback with parameters: QueueInterface $this, QueueMessage
+     */
+    public function drain(callable $callback): void;
 
     public function ack(QueueMessage $message): void;
 

--- a/src/Rabbit/Queue.php
+++ b/src/Rabbit/Queue.php
@@ -86,7 +86,7 @@ class Queue implements QueueInterface
     }
 
 
-    public function consume(callable $callback, float $timeoutSecs, ?float $pollIntervalSecs = null): void
+    public function consume(callable $callback, ?float $timeoutSecs, ?float $pollIntervalSecs = null): void
     {
         throw new UnsupportedOperationException("Consumption is not supported by RabbitQueue");
     }

--- a/src/Rabbit/Queue.php
+++ b/src/Rabbit/Queue.php
@@ -86,11 +86,15 @@ class Queue implements QueueInterface
     }
 
 
-    public function consume(callable $callback, ?float $timeoutSecs, ?float $pollIntervalSecs = null): void
+    public function consume(callable $callback, float $timeoutSecs, ?float $pollIntervalSecs = null): void
     {
         throw new UnsupportedOperationException("Consumption is not supported by RabbitQueue");
     }
 
+    public function drain(callable $callback): void
+    {
+        throw new UnsupportedOperationException("Consumption is not supported by RabbitQueue");
+    }
 
     public function ack(QueueMessage $message): void
     {


### PR DESCRIPTION
…tely exits. This avoids timeouts prolonging tests unnecessarily and avoids flaky test results due to tests running slower than expected